### PR TITLE
Corrige verificación del hash inicial

### DIFF
--- a/TP_1/verificar_cadena.py
+++ b/TP_1/verificar_cadena.py
@@ -18,7 +18,9 @@ def main():
         return
 
     corrupt = []
-    prev = "GENESIS"
+    # El verificador debe comenzar con el mismo hash inicial
+    # que utiliza la generación de la cadena (64 ceros).
+    prev = "0" * 64
     freqs, press, oxys = [], [], []
     diastolic = []
     alertas = 0


### PR DESCRIPTION
## Summary
- Corrige verificador de la cadena de bloques utilizando el hash inicial correcto (64 ceros) y añade comentarios aclaratorios.

## Testing
- `python -m py_compile verificar_cadena.py`
- `python verificar_cadena.py`


------
https://chatgpt.com/codex/tasks/task_e_68a758eac3a4832a9993adca7f0b6403